### PR TITLE
Changing FMP icon in the docs

### DIFF
--- a/public_docs/web/templates/layout/app.html.eex
+++ b/public_docs/web/templates/layout/app.html.eex
@@ -14,7 +14,7 @@
 
   <body>
     <div style="text-align: center;">
-      <img style="width:300px;" src="http://styleguide.findmypast.com/dist/3653463c28a308062ef498d51eb6d9be.png">
+      <img style="width:300px;" src="http://www.findmypast.co.uk/images/opengraph/fmp_new_logo.jpg">
     </div>
     
     <h2 align="center">Findmypast API Documentation</h2>


### PR DESCRIPTION
The style guide icon doesn't work if you are not in the VPN:
http://styleguide.findmypast.com/dist/3653463c28a308062ef498d51eb6d9be.png

Changing to FMP icon.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/findmypast/public_docs/3)

<!-- Reviewable:end -->
